### PR TITLE
Restore PDF-AS profile defaults for signature positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+* Restore the pre-0.5 behavior for omitted signature block positioning values:
+  PDF-AS profile defaults are used again instead of explicitly sending automatic
+  placement/zero values from the bundle.
 
 ## v0.6.13
 * Add more translations for additional profiles

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -14,18 +14,22 @@ cm via the DPI, for example "1cm ~ 28.3465pt".
 
 * `page` - The page number where the signature block should be placed, starting
   with 1. A page number larger than the actual page count will append a new page
-  instead. Defaults to the last page, or a newly added page if there isn't
+  instead. If omitted, the PDF-AS profile default is used. Without a profile
+  default, PDF-AS automatically uses the last page or a new page if there isn't
   enough space.
 * `x` - Position of the signature's top left corner in points, from the left of
-  the page. Defaults to the signature block being centered horizontally.
+  the page. If omitted, the PDF-AS profile default is used. Without a profile
+  default, PDF-AS centers the signature block horizontally.
 * `y` - Position of the signature's top left corner in points, from the bottom
-  of the page. Defaults to right after the content on the selected page, or at
+  of the page. If omitted, the PDF-AS profile default is used. Without a profile
+  default, PDF-AS places it right after the content on the selected page, or at
   the top if there is not enough free space.
-* `width` - Width of the signature block in points. Defaults to the default width
-  specified in the backend. Note that making it too small might break the
-  internal layout.
+* `width` - Width of the signature block in points. If omitted, the PDF-AS
+  profile default is used. Without a profile default, PDF-AS uses automatic
+  width. Note that making it too small might break the internal layout.
 * `rotation` - Absolute rotation of the signature block in degrees, counterclockwise.
-  Defaults to 0.
+  If omitted, the PDF-AS profile default is used. Without a profile default,
+  PDF-AS uses 0 degrees.
 
 In case you don't want to have a visible signature block at all you can set `invisible` to `true`:
 

--- a/src/Api/AdvancedlySignedDocument.php
+++ b/src/Api/AdvancedlySignedDocument.php
@@ -59,27 +59,27 @@ use Symfony\Component\Serializer\Annotation\Groups;
                                         'format' => 'binary',
                                     ],
                                     'x' => [
-                                        'description' => 'Position of the signature from the left (in points)',
+                                        'description' => 'Position of the signature from the left (in points). If omitted, the PDF-AS profile default is used.',
                                         'type' => 'number',
                                         'example' => '300',
                                     ],
                                     'y' => [
-                                        'description' => 'Position of the signature from the bottom (in points)',
+                                        'description' => 'Position of the signature from the bottom (in points). If omitted, the PDF-AS profile default is used.',
                                         'type' => 'number',
                                         'example' => '400',
                                     ],
                                     'r' => [
-                                        'description' => 'Rotation of the signature counterclockwise (in degrees)',
+                                        'description' => 'Rotation of the signature counterclockwise (in degrees). If omitted, the PDF-AS profile default is used.',
                                         'type' => 'number',
                                         'example' => '0',
                                     ],
                                     'w' => [
-                                        'description' => 'Width of the signature (in points)',
+                                        'description' => 'Width of the signature (in points). If omitted, the PDF-AS profile default is used.',
                                         'type' => 'number',
                                         'example' => '340',
                                     ],
                                     'p' => [
-                                        'description' => 'Page number the signature should be placed (starting with 1)',
+                                        'description' => 'Page number the signature should be placed (starting with 1). If omitted, the PDF-AS profile default is used.',
                                         'type' => 'number',
                                         'example' => '2',
                                     ],

--- a/src/Api/CreateAdvancedlySignedDocumentAction.php
+++ b/src/Api/CreateAdvancedlySignedDocumentAction.php
@@ -64,19 +64,19 @@ final class CreateAdvancedlySignedDocumentAction
 
         $hasPositionParams = false;
 
-        $x = SignatureBlockPosition::AUTO;
+        $x = SignatureBlockPosition::PROFILE_DEFAULT;
         if (Utils::requestGet($request, 'x', '') !== '') {
             $x = (float) Utils::requestGet($request, 'x');
             $hasPositionParams = true;
         }
 
-        $y = SignatureBlockPosition::AUTO;
+        $y = SignatureBlockPosition::PROFILE_DEFAULT;
         if (Utils::requestGet($request, 'y', '') !== '') {
             $y = (float) Utils::requestGet($request, 'y');
             $hasPositionParams = true;
         }
 
-        $width = SignatureBlockPosition::AUTO;
+        $width = SignatureBlockPosition::PROFILE_DEFAULT;
         if ($request->request->has('width')) {
             $width = $request->request->filter('width', filter: \FILTER_VALIDATE_FLOAT);
             $hasPositionParams = true;
@@ -85,7 +85,7 @@ final class CreateAdvancedlySignedDocumentAction
             $hasPositionParams = true;
         }
 
-        $rotation = 0.0;
+        $rotation = SignatureBlockPosition::PROFILE_DEFAULT;
         if ($request->request->has('rotation')) {
             $rotation = $request->request->filter('rotation', filter: \FILTER_VALIDATE_FLOAT);
             $hasPositionParams = true;
@@ -94,7 +94,7 @@ final class CreateAdvancedlySignedDocumentAction
             $hasPositionParams = true;
         }
 
-        $page = SignatureBlockPosition::AUTO;
+        $page = SignatureBlockPosition::PROFILE_DEFAULT;
         if ($request->request->has('page')) {
             $page = $request->request->getInt('page');
             $hasPositionParams = true;
@@ -125,13 +125,13 @@ final class CreateAdvancedlySignedDocumentAction
         $requestId = PdfAsApiUtils::generateRequestId();
 
         // if for whatever reason a negative value appears where it shouldnt be
-        // then fallback to auto placement
-        if ($hasPositionParams && ($x < 0 || $y < 0 || $width < 0)) {
-            $x = SignatureBlockPosition::AUTO;
-            $y = SignatureBlockPosition::AUTO;
-            $page = SignatureBlockPosition::AUTO;
-            $width = SignatureBlockPosition::AUTO;
-            $rotation = 0.0;
+        // then fallback to the PDF-AS profile defaults
+        if ($hasPositionParams && ((is_float($x) && $x < 0) || (is_float($y) && $y < 0) || (is_float($width) && $width < 0))) {
+            $x = SignatureBlockPosition::PROFILE_DEFAULT;
+            $y = SignatureBlockPosition::PROFILE_DEFAULT;
+            $page = SignatureBlockPosition::PROFILE_DEFAULT;
+            $width = SignatureBlockPosition::PROFILE_DEFAULT;
+            $rotation = SignatureBlockPosition::PROFILE_DEFAULT;
         }
 
         $blockPosition = new SignatureBlockPosition(x: $x, y: $y, width : $width, rotation: $rotation, page: $page);

--- a/src/Api/CreateQualifiedBatchSigningRequestAction.php
+++ b/src/Api/CreateQualifiedBatchSigningRequestAction.php
@@ -127,7 +127,7 @@ final class CreateQualifiedBatchSigningRequestAction
     {
         $hasPositionParams = false;
 
-        $x = SignatureBlockPosition::AUTO;
+        $x = SignatureBlockPosition::PROFILE_DEFAULT;
         if (isset($requestData['x'])) {
             $x = $requestData['x'];
             if (!is_int($x) && !is_float($x)) {
@@ -135,7 +135,7 @@ final class CreateQualifiedBatchSigningRequestAction
             }
             $hasPositionParams = true;
         }
-        $y = SignatureBlockPosition::AUTO;
+        $y = SignatureBlockPosition::PROFILE_DEFAULT;
         if (isset($requestData['y'])) {
             $y = $requestData['y'];
             if (!is_int($y) && !is_float($y)) {
@@ -143,7 +143,7 @@ final class CreateQualifiedBatchSigningRequestAction
             }
             $hasPositionParams = true;
         }
-        $width = SignatureBlockPosition::AUTO;
+        $width = SignatureBlockPosition::PROFILE_DEFAULT;
         if (isset($requestData['width'])) {
             $width = $requestData['width'];
             if (!is_int($width) && !is_float($width)) {
@@ -151,7 +151,7 @@ final class CreateQualifiedBatchSigningRequestAction
             }
             $hasPositionParams = true;
         }
-        $rotation = 0.0;
+        $rotation = SignatureBlockPosition::PROFILE_DEFAULT;
         if (isset($requestData['rotation'])) {
             $rotation = $requestData['rotation'];
             if (!is_int($rotation) && !is_float($rotation)) {
@@ -159,7 +159,7 @@ final class CreateQualifiedBatchSigningRequestAction
             }
             $hasPositionParams = true;
         }
-        $page = SignatureBlockPosition::AUTO;
+        $page = SignatureBlockPosition::PROFILE_DEFAULT;
         if (isset($requestData['page'])) {
             $page = $requestData['page'];
             if (!is_int($page)) {

--- a/src/Api/CreateQualifiedSigningRequestAction.php
+++ b/src/Api/CreateQualifiedSigningRequestAction.php
@@ -51,19 +51,19 @@ final class CreateQualifiedSigningRequestAction
 
         $hasPositionParams = false;
 
-        $x = SignatureBlockPosition::AUTO;
+        $x = SignatureBlockPosition::PROFILE_DEFAULT;
         if (Utils::requestGet($request, 'x', '') !== '') {
             $x = (float) Utils::requestGet($request, 'x');
             $hasPositionParams = true;
         }
 
-        $y = SignatureBlockPosition::AUTO;
+        $y = SignatureBlockPosition::PROFILE_DEFAULT;
         if (Utils::requestGet($request, 'y', '') !== '') {
             $y = (float) Utils::requestGet($request, 'y');
             $hasPositionParams = true;
         }
 
-        $width = SignatureBlockPosition::AUTO;
+        $width = SignatureBlockPosition::PROFILE_DEFAULT;
         if ($request->request->has('width')) {
             $width = $request->request->filter('width', filter: FILTER_VALIDATE_FLOAT);
             $hasPositionParams = true;
@@ -72,7 +72,7 @@ final class CreateQualifiedSigningRequestAction
             $hasPositionParams = true;
         }
 
-        $rotation = 0.0;
+        $rotation = SignatureBlockPosition::PROFILE_DEFAULT;
         if ($request->request->has('rotation')) {
             $rotation = $request->request->filter('rotation', filter: FILTER_VALIDATE_FLOAT);
             $hasPositionParams = true;
@@ -81,7 +81,7 @@ final class CreateQualifiedSigningRequestAction
             $hasPositionParams = true;
         }
 
-        $page = SignatureBlockPosition::AUTO;
+        $page = SignatureBlockPosition::PROFILE_DEFAULT;
         if ($request->request->has('page')) {
             $page = $request->request->getInt('page');
             $hasPositionParams = true;

--- a/src/Api/QualifiedBatchSigningRequest.php
+++ b/src/Api/QualifiedBatchSigningRequest.php
@@ -65,27 +65,27 @@ use Symfony\Component\Serializer\Annotation\Groups;
                                                     'example' => 'default',
                                                 ],
                                                 'x' => [
-                                                    'description' => 'Position of the signature from the left (in points)',
+                                                    'description' => 'Position of the signature from the left (in points). If omitted, the PDF-AS profile default is used.',
                                                     'type' => 'number',
                                                     'example' => '300',
                                                 ],
                                                 'y' => [
-                                                    'description' => 'Position of the signature from the bottom (in points)',
+                                                    'description' => 'Position of the signature from the bottom (in points). If omitted, the PDF-AS profile default is used.',
                                                     'type' => 'number',
                                                     'example' => '400',
                                                 ],
                                                 'rotation' => [
-                                                    'description' => 'Rotation of the signature counterclockwise (in degrees)',
+                                                    'description' => 'Rotation of the signature counterclockwise (in degrees). If omitted, the PDF-AS profile default is used.',
                                                     'type' => 'number',
                                                     'example' => '0',
                                                 ],
                                                 'width' => [
-                                                    'description' => 'Width of the signature (in points)',
+                                                    'description' => 'Width of the signature (in points). If omitted, the PDF-AS profile default is used.',
                                                     'type' => 'number',
                                                     'example' => '340',
                                                 ],
                                                 'page' => [
-                                                    'description' => 'Page number the signature should be placed (starting with 1)',
+                                                    'description' => 'Page number the signature should be placed (starting with 1). If omitted, the PDF-AS profile default is used.',
                                                     'type' => 'number',
                                                     'example' => '2',
                                                 ],

--- a/src/Api/QualifiedSigningRequest.php
+++ b/src/Api/QualifiedSigningRequest.php
@@ -60,27 +60,27 @@ use Symfony\Component\Serializer\Annotation\Groups;
                                         'format' => 'binary',
                                     ],
                                     'x' => [
-                                        'description' => 'Position of the signature from the left (in points)',
+                                        'description' => 'Position of the signature from the left (in points). If omitted, the PDF-AS profile default is used.',
                                         'type' => 'number',
                                         'example' => '300',
                                     ],
                                     'y' => [
-                                        'description' => 'Position of the signature from the bottom (in points)',
+                                        'description' => 'Position of the signature from the bottom (in points). If omitted, the PDF-AS profile default is used.',
                                         'type' => 'number',
                                         'example' => '400',
                                     ],
                                     'r' => [
-                                        'description' => 'Rotation of the signature counterclockwise (in degrees)',
+                                        'description' => 'Rotation of the signature counterclockwise (in degrees). If omitted, the PDF-AS profile default is used.',
                                         'type' => 'number',
                                         'example' => '0',
                                     ],
                                     'w' => [
-                                        'description' => 'Width of the signature (in points)',
+                                        'description' => 'Width of the signature (in points). If omitted, the PDF-AS profile default is used.',
                                         'type' => 'number',
                                         'example' => '340',
                                     ],
                                     'p' => [
-                                        'description' => 'Page number the signature should be placed (starting with 1)',
+                                        'description' => 'Page number the signature should be placed (starting with 1). If omitted, the PDF-AS profile default is used.',
                                         'type' => 'number',
                                         'example' => '2',
                                     ],

--- a/src/PdfAsApi/SignatureBlockPosition.php
+++ b/src/PdfAsApi/SignatureBlockPosition.php
@@ -6,43 +6,51 @@ namespace Dbp\Relay\EsignBundle\PdfAsApi;
 
 class SignatureBlockPosition
 {
+    public const PROFILE_DEFAULT = null;
     public const AUTO = 'auto';
     public const PAGE_NEW = 'new';
     public const PAGE_LAST = 'last';
 
     /**
-     * @param string|float $x            X-coordinate of the top-left corner. Use 'auto' for automatic positioning.
-     * @param string|float $y            Y-coordinate of the top-left corner. Use 'auto' for automatic positioning.
-     * @param string|float $width        Width of the signature block. Must be > 0 when numeric.
-     * @param string|int   $page         Page to place the signature on. 'auto', 'new', 'last', or a page number.
-     * @param float        $footerHeight Y-offset for footer in PDF User Space units. Only used when yPosition is 'auto'.
-     * @param float        $rotation     rotation in degrees (0-360)
+     * @param string|float|null $x            X-coordinate of the top-left corner. Use null for the PDF-AS profile default or 'auto' for automatic positioning.
+     * @param string|float|null $y            Y-coordinate of the top-left corner. Use null for the PDF-AS profile default or 'auto' for automatic positioning.
+     * @param string|float|null $width        Width of the signature block. Must be > 0 when numeric.
+     * @param string|int|null   $page         Page to place the signature on. null, 'auto', 'new', 'last', or a page number.
+     * @param float|null        $footerHeight Y-offset for footer in PDF User Space units. Only used when yPosition is 'auto'.
+     * @param float|null        $rotation     rotation in degrees (0-360)
      */
     public function __construct(
-        public readonly string|float $x = self::AUTO,
-        public readonly string|float $y = self::AUTO,
-        public readonly string|float $width = self::AUTO,
-        public readonly string|int $page = self::AUTO,
-        public readonly float $footerHeight = 0.0,
-        public readonly float $rotation = 0.0,
+        public readonly string|float|null $x = self::PROFILE_DEFAULT,
+        public readonly string|float|null $y = self::PROFILE_DEFAULT,
+        public readonly string|float|null $width = self::PROFILE_DEFAULT,
+        public readonly string|int|null $page = self::PROFILE_DEFAULT,
+        public readonly ?float $footerHeight = self::PROFILE_DEFAULT,
+        public readonly ?float $rotation = self::PROFILE_DEFAULT,
     ) {
         $this->validate();
     }
 
     /**
-     * Serializes to the PDF-AS position string format.
+     * Serializes to the PDF-AS position string format, or null if all values use the profile default.
      * Example: x:auto;y:100.5;w:auto;p:last;f:20;r:90.
      */
-    public function toPdfAsFormat(): string
+    public function toPdfAsFormat(): ?string
     {
-        return implode(';', [
-            'x:'.$this->x,
-            'y:'.$this->y,
-            'w:'.$this->width,
-            'p:'.$this->page,
-            'f:'.$this->footerHeight,
-            'r:'.$this->rotation,
-        ]);
+        $parts = [];
+        foreach ([
+            'x' => $this->x,
+            'y' => $this->y,
+            'w' => $this->width,
+            'p' => $this->page,
+            'f' => $this->footerHeight,
+            'r' => $this->rotation,
+        ] as $key => $value) {
+            if ($value !== null) {
+                $parts[] = $key.':'.$value;
+            }
+        }
+
+        return $parts === [] ? null : implode(';', $parts);
     }
 
     private function validate(): void
@@ -74,11 +82,11 @@ class SignatureBlockPosition
             throw new \InvalidArgumentException('Page number must be greater than 0.');
         }
 
-        if ($this->footerHeight < 0) {
+        if ($this->footerHeight !== null && $this->footerHeight < 0) {
             throw new \InvalidArgumentException('Footer height must be a non-negative number.');
         }
 
-        if ($this->rotation < 0 || $this->rotation > 360) {
+        if ($this->rotation !== null && ($this->rotation < 0 || $this->rotation > 360)) {
             throw new \InvalidArgumentException('Rotation must be between 0 and 360 degrees.');
         }
     }

--- a/tests/PdfAsApi/SignatureBlockPositionTest.php
+++ b/tests/PdfAsApi/SignatureBlockPositionTest.php
@@ -13,18 +13,24 @@ class SignatureBlockPositionTest extends TestCase
     {
         $pos = new SignatureBlockPosition();
 
-        $this->assertSame(SignatureBlockPosition::AUTO, $pos->x);
-        $this->assertSame(SignatureBlockPosition::AUTO, $pos->y);
-        $this->assertSame(SignatureBlockPosition::AUTO, $pos->width);
-        $this->assertSame(SignatureBlockPosition::AUTO, $pos->page);
-        $this->assertSame(0.0, $pos->footerHeight);
-        $this->assertSame(0.0, $pos->rotation);
+        $this->assertSame(SignatureBlockPosition::PROFILE_DEFAULT, $pos->x);
+        $this->assertSame(SignatureBlockPosition::PROFILE_DEFAULT, $pos->y);
+        $this->assertSame(SignatureBlockPosition::PROFILE_DEFAULT, $pos->width);
+        $this->assertSame(SignatureBlockPosition::PROFILE_DEFAULT, $pos->page);
+        $this->assertSame(SignatureBlockPosition::PROFILE_DEFAULT, $pos->footerHeight);
+        $this->assertSame(SignatureBlockPosition::PROFILE_DEFAULT, $pos->rotation);
     }
 
     public function testToPdfAsStringWithDefaults(): void
     {
         $pos = new SignatureBlockPosition();
-        $this->assertSame('x:auto;y:auto;w:auto;p:auto;f:0;r:0', $pos->toPdfAsFormat());
+        $this->assertNull($pos->toPdfAsFormat());
+    }
+
+    public function testToPdfAsStringSkipsProfileDefaults(): void
+    {
+        $pos = new SignatureBlockPosition(x: 0.0, width: 100.0, rotation: 0.0);
+        $this->assertSame('x:0;w:100;r:0', $pos->toPdfAsFormat());
     }
 
     public function testToPdfAsStringWithNumericValues(): void


### PR DESCRIPTION
Omitted signature block position values now resolve to the default configured in the PDF-AS profile instead of being sent as explicit auto/zero values. This restores the pre-0.5 behavior, which was accidentally changed when positioning defaults were moved into the bundle without accounting for PDF-AS profile-level overrides.

Fixes #290